### PR TITLE
Add new condition to filter tokenSymbol search explorer

### DIFF
--- a/db/mgo.go
+++ b/db/mgo.go
@@ -864,6 +864,7 @@ func (m *mongoDB) AddressByName(ctx context.Context, name string) ([]*types.Addr
 	)
 	crit := []bson.M{
 		{"name": bson.D{{"$regex", primitive.Regex{Pattern: name, Options: "i"}}}},
+		{"tokenSymbol": bson.D{{"$regex", primitive.Regex{Pattern: name, Options: "i"}}}},
 	}
 	if strings.HasPrefix(name, "0x") {
 		crit = append(crit, bson.M{"address": bson.D{{"$regex", primitive.Regex{Pattern: name, Options: "i"}}}})


### PR DESCRIPTION
- Add a new condition to filter field `tokenSymbol` search explorer
- Current action: Cannot search KRC token by symbols
- New action: Can search KRC token by symbols