### PR TITLE
Fix TxByHash API, modify update/insert contract APIs

### DIFF
--- a/cfg/const.go
+++ b/cfg/const.go
@@ -58,14 +58,15 @@ const (
 	ParamsContractName        = "Params Contract"
 	UpdateStatsInterval       = 10
 
-	SMCTypePrefix    = "SMCType:"
-	SMCTypeKRC20     = "KRC20"
-	SMCTypeKRC721    = "KRC721"
-	SMCTypeValidator = "Validator"
-	KRCTransferTopic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+	SMCTypePrefix         = "SMCType:"
+	SMCTypeKRC20          = "KRC20"
+	SMCTypeKRC721         = "KRC721"
+	SMCTypeValidator      = "Validator"
+	KRCTransferTopic      = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+	KRCTransferMethodName = "Transfer"
 
-	FilterLogsInterval uint64 = 1000 // number of blocks
-	DefaultKRCTokenLogo = "https://kardiachain-explorer.s3-ap-southeast-1.amazonaws.com/explorer.kardiachain.io/logo/default.png"
+	FilterLogsInterval  uint64 = 1000 // number of blocks
+	DefaultKRCTokenLogo        = "https://kardiachain-explorer.s3-ap-southeast-1.amazonaws.com/explorer.kardiachain.io/logo/default.png"
 )
 
 var (

--- a/server/rest.go
+++ b/server/rest.go
@@ -873,8 +873,13 @@ func (s *Server) TxByHash(c echo.Context) error {
 		return api.Invalid.Build(c)
 	}
 
+	receipt, err := s.kaiClient.GetTransactionReceipt(ctx, txHash)
+	if err != nil {
+		s.Logger.Warn("cannot get receipt by hash from RPC:", zap.String("txHash", txHash))
+	}
+
 	var tx *types.Transaction
-	tx, err := s.dbClient.TxByHash(ctx, txHash)
+	tx, err = s.dbClient.TxByHash(ctx, txHash)
 	if err != nil {
 		// try to get tx by hash through RPC
 		s.Logger.Info("cannot get tx by hash from db:", zap.String("txHash", txHash))
@@ -882,10 +887,6 @@ func (s *Server) TxByHash(c echo.Context) error {
 		if err != nil {
 			s.Logger.Warn("cannot get tx by hash from RPC:", zap.String("txHash", txHash))
 			return api.Invalid.Build(c)
-		}
-		receipt, err := s.kaiClient.GetTransactionReceipt(ctx, txHash)
-		if err != nil {
-			s.Logger.Warn("cannot get receipt by hash from RPC:", zap.String("txHash", txHash))
 		}
 		if receipt != nil {
 			tx.Logs = receipt.Logs
@@ -926,21 +927,45 @@ func (s *Server) TxByHash(c echo.Context) error {
 		tx.DecodedInputData = functionCall
 	}
 
-	filter := &types.EventsFilter{
-		TxHash: txHash,
+	filter := &types.InternalTxsFilter{
+		TransactionHash: txHash,
 	}
-	events, _, err := s.dbClient.GetListEvents(ctx, filter)
+	iTxs, _, err := s.dbClient.GetListInternalTxs(ctx, filter)
 	if err != nil {
-		s.logger.Warn("Cannot get events from db", zap.Error(err))
+		s.logger.Warn("Cannot get internal transactions from db", zap.Error(err))
 	}
-	internalTxs := make([]*InternalTransaction, len(events))
-	for i := range events {
+	internalTxs := make([]*InternalTransaction, len(iTxs))
+	for i := range iTxs {
+		logIndex, _ := iTxs[i].LogIndex.(uint)
 		internalTxs[i] = &InternalTransaction{
-			Log: events[i],
+			Log: &types.Log{
+				Address:    iTxs[i].Contract,
+				MethodName: cfg.KRCTransferMethodName,
+				Arguments: map[string]interface{}{
+					"from":  iTxs[i].From,
+					"to":    iTxs[i].To,
+					"value": iTxs[i].Value,
+				},
+				BlockHeight: iTxs[i].BlockHeight,
+				Time:        iTxs[i].Time,
+				TxHash:      iTxs[i].TransactionHash,
+				Index:       logIndex,
+			},
+			From:  iTxs[i].From,
+			To:    iTxs[i].To,
+			Value: iTxs[i].Value,
 		}
-		krcTokenInfo, err = s.getKRCTokenInfo(ctx, events[i].Address)
+		fromInfo, _ := s.getAddressInfo(ctx, iTxs[i].From)
+		if fromInfo != nil {
+			internalTxs[i].FromName = fromInfo.Name
+		}
+		toInfo, _ := s.getAddressInfo(ctx, iTxs[i].To)
+		if toInfo != nil {
+			internalTxs[i].ToName = toInfo.Name
+		}
+		krcTokenInfo, err = s.getKRCTokenInfo(ctx, iTxs[i].Contract)
 		if err != nil {
-			s.logger.Info("Cannot get KRC Token Info", zap.String("smcAddress", events[i].Address), zap.Error(err))
+			s.logger.Info("Cannot get KRC Token Info", zap.String("smcAddress", iTxs[i].Contract), zap.Error(err))
 			continue
 		}
 		internalTxs[i].KRCTokenInfo = krcTokenInfo
@@ -1232,6 +1257,8 @@ func (s *Server) ContractEvents(c echo.Context) error {
 		page, limit  int
 		err          error
 		krcTokenInfo *types.KRCTokenInfo
+		events       []*types.Log
+		total        uint64
 	)
 	pagination, page, limit := getPagingOption(c)
 	filter := &types.EventsFilter{
@@ -1240,9 +1267,30 @@ func (s *Server) ContractEvents(c echo.Context) error {
 		MethodName:      c.QueryParam("methodName"),
 		TxHash:          c.QueryParam("txHash"),
 	}
-	events, total, err := s.dbClient.GetListEvents(ctx, filter)
-	if err != nil {
-		s.logger.Warn("Cannot get events from db", zap.Error(err))
+	if filter.MethodName != "" || filter.ContractAddress != "" {
+		events, total, err = s.dbClient.GetListEvents(ctx, filter)
+		if err != nil {
+			s.logger.Warn("Cannot get events from db", zap.Error(err))
+		}
+	} else {
+		receipt, err := s.kaiClient.GetTransactionReceipt(ctx, filter.TxHash)
+		if err != nil {
+			s.logger.Warn("Cannot get receipt from RPC", zap.Error(err))
+			return api.Invalid.Build(c)
+		}
+		for i := range receipt.Logs {
+			smcABI, err := s.getSMCAbi(ctx, &receipt.Logs[i])
+			if err != nil {
+				events = append(events, &receipt.Logs[i])
+				continue
+			}
+			unpackedLog, err := s.kaiClient.UnpackLog(&receipt.Logs[i], smcABI)
+			if err != nil {
+				events = append(events, &receipt.Logs[i])
+				continue
+			}
+			events = append(events, unpackedLog)
+		}
 	}
 	result := make([]*InternalTransaction, len(events))
 	for i := range events {
@@ -1400,16 +1448,9 @@ func (s *Server) InsertContract(c echo.Context) error {
 		addrInfo.TotalSupply = krcTokenInfoFromRPC.TokenName
 		addrInfo.Decimals = krcTokenInfoFromRPC.Decimals
 	}
-	currTokenInfo, _ := s.dbClient.AddressByHash(ctx, addrInfo.Address)
 	if err := s.dbClient.InsertContract(ctx, &contract, &addrInfo); err != nil {
 		lgr.Error("cannot bind insert", zap.Error(err))
 		return api.InternalServer.Build(c)
-	}
-	// retrieve old token transfer before we add this token to database as KRC
-	if (currTokenInfo != nil && currTokenInfo.KrcTypes == "" && currTokenInfo.TokenName == "" && currTokenInfo.TokenSymbol == "") || currTokenInfo == nil {
-		if err := s.insertHistoryTransferKRC(ctx, addrInfo.Address); err != nil {
-			lgr.Error("cannot retrieve history transfer of KRC token", zap.Error(err), zap.String("address", addrInfo.Address))
-		}
 	}
 
 	return api.OK.Build(c)
@@ -1466,16 +1507,9 @@ func (s *Server) UpdateContract(c echo.Context) error {
 		addrInfo.TotalSupply = krcTokenInfoFromRPC.TotalSupply
 		addrInfo.Decimals = krcTokenInfoFromRPC.Decimals
 	}
-	currTokenInfo, _ := s.dbClient.AddressByHash(ctx, addrInfo.Address)
 	if err := s.dbClient.UpdateContract(ctx, &contract, &addrInfo); err != nil {
 		lgr.Error("cannot bind insert", zap.Error(err))
 		return api.InternalServer.Build(c)
-	}
-	// retrieve old token transfer before we add this token to database as KRC
-	if (currTokenInfo != nil && currTokenInfo.KrcTypes == "" && currTokenInfo.TokenName == "" && currTokenInfo.TokenSymbol == "") || currTokenInfo == nil {
-		if err := s.insertHistoryTransferKRC(ctx, addrInfo.Address); err != nil {
-			lgr.Error("cannot retrieve history transfer of KRC token", zap.Error(err), zap.String("address", addrInfo.Address))
-		}
 	}
 
 	return api.OK.SetData(addrInfo).Build(c)


### PR DESCRIPTION
# Description

Fixes issue https://github.com/kardiachain/kardia-explorer-backend/issues/125

## Type of change

- [X] Fix `TxByHash` API not to rely on `Events` collection, need to use `InternalTransactions` collection instead
- [X] Update/Insert contract API no longer refill old internal transactions, use `UpdateInternalTxs` API instead