### PR TITLE
Implement tracing transaction for revert reason in TxByHash API

### DIFF
--- a/kardia/client.go
+++ b/kardia/client.go
@@ -42,6 +42,7 @@ type ClientInterface interface {
 	NodesInfo(ctx context.Context) ([]*types.NodeInfo, error)
 	Validator(ctx context.Context, address string) (*types.Validator, error)
 	Validators(ctx context.Context) ([]*types.Validator, error)
+	TraceTransaction(ctx context.Context, hash string) (*types.TxTraceResult, error)
 
 	// staking related methods
 	GetValidatorsByDelegator(ctx context.Context, delAddr common.Address) ([]*types.ValidatorsByDelegator, error)

--- a/kardia/rpc.go
+++ b/kardia/rpc.go
@@ -331,10 +331,13 @@ func (ec *Client) NodesInfo(ctx context.Context) ([]*types.NodeInfo, error) {
 	return nodes, nil
 }
 
-func (ec *Client) Datadir(ctx context.Context) (string, error) {
-	var result string
-	err := ec.chooseClient().c.CallContext(ctx, &result, "node_datadir")
-	return result, err
+func (ec *Client) TraceTransaction(ctx context.Context, hash string) (*types.TxTraceResult, error) {
+	var result *types.TxTraceResult
+	err := ec.chooseClient().c.CallContext(ctx, &result, "debug_traceTransaction", common.HexToHash(hash))
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 //func (ec *Client) Validators(ctx context.Context) (*types.Validators, error) {

--- a/server/models.go
+++ b/server/models.go
@@ -80,6 +80,7 @@ type Transaction struct {
 	TransactionIndex   uint                   `json:"transactionIndex"`
 	LogsBloom          coreTypes.Bloom        `json:"logsBloom"`
 	Root               string                 `json:"root"`
+	RevertReason       string                 `json:"revertReason"`
 }
 
 type NodeInfo struct {

--- a/server/rest.go
+++ b/server/rest.go
@@ -1007,7 +1007,12 @@ func (s *Server) TxByHash(c echo.Context) error {
 		result.IsInValidatorsList = true
 		return api.OK.SetData(result).Build(c)
 	}
-
+	if result.Status == 0 {
+		txTraceResult, _ := s.kaiClient.TraceTransaction(ctx, result.Hash)
+		if txTraceResult != nil {
+			result.RevertReason = txTraceResult.RevertReason
+		}
+	}
 	lgr.Debug("TransactionInfo", zap.Any("Tx", result))
 	return api.OK.SetData(result).Build(c)
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -52,3 +52,10 @@ type CallArgsJSON struct {
 	Value    *big.Int `json:"value"`    // amount of HYDRO sent along with the call
 	Data     string   `json:"data"`     // input data, usually an ABI-encoded contract method invocation
 }
+
+type TxTraceResult struct {
+	UsedGas      uint64 `json:"usedGas"`
+	Err          error  `json:"err"`
+	ReturnData   string `json:"returnData"`
+	RevertReason string `json:"revertReason"`
+}

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -54,8 +54,8 @@ type CallArgsJSON struct {
 }
 
 type TxTraceResult struct {
-	UsedGas      uint64 `json:"usedGas"`
-	Err          error  `json:"err"`
-	ReturnData   string `json:"returnData"`
-	RevertReason string `json:"revertReason"`
+	UsedGas      uint64      `json:"usedGas"`
+	Err          interface{} `json:"err"`
+	ReturnData   string      `json:"returnData"`
+	RevertReason string      `json:"revertReason"`
 }


### PR DESCRIPTION
# Type of change

- [X] Implement `debug_traceTransaction` method in KaiClient
- [X] Include revert reason of transaction (if any) in `TxByHash` API

Example:
```
curl --location --request GET 'https://backend-dev.kardiachain.io/api/v1/txs/0xa6b3706928f808b811a2c0e656eda580777f9f1dfbc7e0b2a8a450a11c64f0de'
```
Response:
```
{
    "code": 1000,
    "msg": "Success",
    "data": {
        "blockHash": "0x22e661c210087e1a33885abfbc458c249ce60814b62ed1f8d3a9b2148ba59cc3",
        "blockNumber": 379613,
        "hash": "0xa6b3706928f808b811a2c0e656eda580777f9f1dfbc7e0b2a8a450a11c64f0de",
        "from": "0xE09913f6Ecf7b64C6A14A8145b4ac2B51111774c",
        "to": "0x2333b9f09fAd1c30d108742C2097498d84413588",
        "isInValidatorsList": false,
        "role": 0,
        "status": 0,
        "contractAddress": "0x",
        "value": "0",
        "gasPrice": 1000000000,
        "gas": 5000000,
        "gasUsed": 44359,
        "txFee": "44359000000000",
        "nonce": 704,
        "time": "2021-05-20T11:32:09.704216265Z",
        "input": "0xe8e337000000000000000000000000004f41c59a6837fea2a5de6ae3397b2c21d9bc6779000000000000000000000000dafa0cf0fe077e8f31c7f29cfd15c81bb248ee190000000000000000000000000000000000000000000000056bc75e27799967e0000000000000000000000000000000000000000000000000000000ee0e677ebb0000000000000000000000000000000000000000000000055de6a773e157f70a000000000000000000000000000000000000000000000000000000ebacfaf0aa000000000000000000000000e09913f6ecf7b64c6a14a8145b4ac2b51111774c00000000000000000000000000000000000000000000000000000179898dd886",
        "logs": [],
        "transactionIndex": 0,
        "logsBloom": [...],
        "root": "",
        "revertReason": "KAIDexRouter: INSUFFICIENT_B_AMOUNT"
    }
}
```